### PR TITLE
update NLDAS regridding script to avoid warning

### DIFF
--- a/forcing/regrid/NLDAS/NLDAS2WRFHydro_regrid.ncl
+++ b/forcing/regrid/NLDAS/NLDAS2WRFHydro_regrid.ncl
@@ -145,6 +145,8 @@ begin
       ncdf->Times = Times  ;output times
       ncdf->valid_time = valid_time
    
+      delete([/Times,valid_time/])
+      
      ;----------------------------------------------------------------------
      ;  Processing...no further modifications should be required...
      ;----------------------------------------------------------------------


### PR DESCRIPTION
Delete `Times` and `valid_times` variables in the NLDAS regrid script after they are used to avoid a warning message.